### PR TITLE
Allow passing a pointer to `libc::epoll_event::u64/data`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@ impl Poll {
     ///
     /// `data` can be a pointer to a user-defined object, useful to keep track of a file descriptor
     /// state.
-    pub fn register<T>(&self, fd: u64, data: *const T) -> Result<(), ()> {
+    pub fn register(&self, fd: u64, data: u64) -> Result<(), ()> {
         let mut event = libc::epoll_event {
             events: (libc::EPOLLIN | libc::EPOLLHUP | libc::EPOLLRDHUP) as u32,
-            u64: data as u64, // epoll_event(3type)
+            u64: data, // epoll_event(3type)
         };
 
         let result = unsafe {


### PR DESCRIPTION
Instead of forcing u64 to always be a fd.
This will allow me to track the state of each file descriptor.

# Screenshots
![A simple non-blocking server that keep the track of open sockets](https://github.com/user-attachments/assets/092e8d3f-22be-4b8e-9ba5-3da1b4793042)

# TODO
- [ ] I had to cast pointers manually and do some unsafe code in `main.rs`, I think the crate should offer some helpers to avoid that.
